### PR TITLE
Use merkle root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ erl_crash.dump
 /.utxo
 /.keys
 mix.lock
+.\#*
+\#*\#

--- a/apps/miner/lib/miner.ex
+++ b/apps/miner/lib/miner.ex
@@ -42,10 +42,9 @@ defmodule Miner do
   end
 
   defp merge_block(coinbase, block) do
-	new_transactions = [coinbase | block.transactions]
-	txoids = Enum.map(new_transactions, &(&1.id))
+  	new_transactions = [coinbase | block.transactions]
+  	txoids = Enum.map(new_transactions, &(&1.id))
 
-	Map.merge(block, %{transactions: new_transactions,
-					   merkle_root: Utilities.calculate_merkle_root(txoids)})
+  	Map.merge(block, %{transactions: new_transactions, merkle_root: Utilities.calculate_merkle_root(txoids)})
   end
 end

--- a/apps/miner/lib/miner.ex
+++ b/apps/miner/lib/miner.ex
@@ -5,6 +5,7 @@ defmodule Miner do
   alias UltraDark.Ledger
   alias UltraDark.Transaction
   alias UltraDark.UtxoStore
+  alias UltraDark.Utilities
 
   def initialize(address) do
     Ledger.initialize
@@ -23,7 +24,7 @@ defmodule Miner do
       block
       |> calculate_coinbase_amount
       |> Transaction.generate_coinbase(address)
-      |> (fn coinbase -> Map.merge(block, %{transactions: [coinbase | block.transactions]}) end).()
+      |> merge_block(block)
       |> Block.mine
 
     IO.puts "\e[34mBlock hash at index #{block.index} calculated:\e[0m #{block.hash}, using nonce: #{block.nonce}"
@@ -38,5 +39,13 @@ defmodule Miner do
 
   defp calculate_coinbase_amount(block) do
     Block.calculate_block_reward(block.index) + Block.total_block_fees(block.transactions)
+  end
+
+  defp merge_block(coinbase, block) do
+	new_transactions = [coinbase | block.transactions]
+	txoids = Enum.map(new_transactions, &(&1.id))
+
+	Map.merge(block, %{transactions: new_transactions,
+					   merkle_root: Utilities.calculate_merkle_root(txoids)})
   end
 end

--- a/core/block.ex
+++ b/core/block.ex
@@ -9,6 +9,7 @@ defmodule UltraDark.Blockchain.Block do
     difficulty: nil,
     nonce: 0,
     timestamp: nil,
+	merkle_root: nil,
     transactions: []
   ]
 
@@ -55,13 +56,13 @@ defmodule UltraDark.Blockchain.Block do
   """
   @spec mine(Block) :: Block
   def mine(block) do
-    %{index: index, hash: hash, previous_hash: previous_hash, timestamp: timestamp, nonce: nonce} = block
+    %{index: index, hash: hash, previous_hash: previous_hash, timestamp: timestamp, nonce: nonce, merkle_root: merkle_root} = block
 
     # I would love to show some sort of hashrate here, but it looks like getting the time with Elixir is incredibly computationally expensive,
     # to the point where mining performance gets HALVED
     IO.write "Block Index: #{index} -- Hash: #{hash} -- Nonce: #{nonce}\r"
 
-    block = %{ block | hash: Utilities.sha_base16([Integer.to_string(index), previous_hash,  timestamp, Integer.to_string(nonce)]) }
+    block = %{ block | hash: Utilities.sha_base16([Integer.to_string(index), previous_hash, timestamp, Integer.to_string(nonce), merkle_root]) }
 
     if hash_beat_target?(block) do
       block

--- a/core/block.ex
+++ b/core/block.ex
@@ -61,7 +61,7 @@ defmodule UltraDark.Blockchain.Block do
     # to the point where mining performance gets HALVED
     IO.write "Block Index: #{index} -- Hash: #{hash} -- Nonce: #{nonce}\r"
 
-    block = %{ block | hash: Utilities.sha_base16([Integer.to_string(index), previous_hash,  timestamp, Integer.to_string(nonce)]) }
+    block = %{ block | hash: Utilities.calculate_merkle_root([Integer.to_string(index), previous_hash,  timestamp, Integer.to_string(nonce)]) }
 
     if hash_beat_target?(block) do
       block

--- a/core/block.ex
+++ b/core/block.ex
@@ -9,7 +9,7 @@ defmodule UltraDark.Blockchain.Block do
     difficulty: nil,
     nonce: 0,
     timestamp: nil,
-	merkle_root: nil,
+	  merkle_root: nil,
     transactions: []
   ]
 

--- a/core/block.ex
+++ b/core/block.ex
@@ -61,7 +61,7 @@ defmodule UltraDark.Blockchain.Block do
     # to the point where mining performance gets HALVED
     IO.write "Block Index: #{index} -- Hash: #{hash} -- Nonce: #{nonce}\r"
 
-    block = %{ block | hash: Utilities.calculate_merkle_root([Integer.to_string(index), previous_hash,  timestamp, Integer.to_string(nonce)]) }
+    block = %{ block | hash: Utilities.sha_base16([Integer.to_string(index), previous_hash,  timestamp, Integer.to_string(nonce)]) }
 
     if hash_beat_target?(block) do
       block

--- a/core/block.ex
+++ b/core/block.ex
@@ -9,7 +9,7 @@ defmodule UltraDark.Blockchain.Block do
     difficulty: nil,
     nonce: 0,
     timestamp: nil,
-	  merkle_root: nil,
+    merkle_root: nil,
     transactions: []
   ]
 

--- a/core/validator.ex
+++ b/core/validator.ex
@@ -30,8 +30,12 @@ defmodule UltraDark.Validator do
   defp valid_prev_hash(prev_hash, last_block_hash) when prev_hash == last_block_hash, do: :ok
   defp valid_prev_hash(prev_hash, last_block_hash) when prev_hash != last_block_hash, do: {:error, "Blocks prev_hash is not equal to the last block's hash"}
 
-  defp valid_hash(%{index: index, previous_hash: previous_hash, timestamp: timestamp, nonce: nonce, hash: hash}) do
-    if Utilities.sha_base16([Integer.to_string(index), previous_hash, timestamp, Integer.to_string(nonce)]) == hash, do: :ok, else: {:error, "Block has invalid hash"}
+  defp valid_hash(%{index: index, previous_hash: previous_hash, timestamp: timestamp, nonce: nonce, hash: hash, merkle_root: merkle_root}) do
+    if Utilities.sha_base16([Integer.to_string(index), previous_hash, timestamp, Integer.to_string(nonce), merkle_root]) == hash do
+	  :ok
+	else
+	  {:error, "Block has invalid hash"}
+	end
   end
 
   @spec valid_coinbase?(Block) :: :ok | {:error, String.t}

--- a/core/validator.ex
+++ b/core/validator.ex
@@ -31,7 +31,7 @@ defmodule UltraDark.Validator do
   defp valid_prev_hash(prev_hash, last_block_hash) when prev_hash != last_block_hash, do: {:error, "Blocks prev_hash is not equal to the last block's hash"}
 
   defp valid_hash(%{index: index, previous_hash: previous_hash, timestamp: timestamp, nonce: nonce, hash: hash}) do
-    if Utilities.calculate_merkle_root([Integer.to_string(index), previous_hash, timestamp, Integer.to_string(nonce)]) == hash, do: :ok, else: {:error, "Block has invalid hash"}
+    if Utilities.sha_base16([Integer.to_string(index), previous_hash, timestamp, Integer.to_string(nonce)]) == hash, do: :ok, else: {:error, "Block has invalid hash"}
   end
 
   @spec valid_coinbase?(Block) :: :ok | {:error, String.t}

--- a/core/validator.ex
+++ b/core/validator.ex
@@ -31,7 +31,7 @@ defmodule UltraDark.Validator do
   defp valid_prev_hash(prev_hash, last_block_hash) when prev_hash != last_block_hash, do: {:error, "Blocks prev_hash is not equal to the last block's hash"}
 
   defp valid_hash(%{index: index, previous_hash: previous_hash, timestamp: timestamp, nonce: nonce, hash: hash}) do
-    if Utilities.sha_base16([Integer.to_string(index), previous_hash, timestamp, Integer.to_string(nonce)]) == hash, do: :ok, else: {:error, "Block has invalid hash"}
+    if Utilities.calculate_merkle_root([Integer.to_string(index), previous_hash, timestamp, Integer.to_string(nonce)]) == hash, do: :ok, else: {:error, "Block has invalid hash"}
   end
 
   @spec valid_coinbase?(Block) :: :ok | {:error, String.t}

--- a/core/validator.ex
+++ b/core/validator.ex
@@ -32,10 +32,10 @@ defmodule UltraDark.Validator do
 
   defp valid_hash(%{index: index, previous_hash: previous_hash, timestamp: timestamp, nonce: nonce, hash: hash, merkle_root: merkle_root}) do
     if Utilities.sha_base16([Integer.to_string(index), previous_hash, timestamp, Integer.to_string(nonce), merkle_root]) == hash do
-	  :ok
-	else
-	  {:error, "Block has invalid hash"}
-	end
+	    :ok
+	  else
+	    {:error, "Block has invalid hash"}
+	  end
   end
 
   @spec valid_coinbase?(Block) :: :ok | {:error, String.t}


### PR DESCRIPTION
Calculating the hash for blocks now uses `calculate_merkle_root` instead of `sha_base16`.

I've compiled and mined a few blocks, and everything seems to work nicely, but I couldn't find any tests to run (so I assume there aren't any) so someone will probably want to check I've not messed something up 😅. 