### PR TITLE
Time how long it takes to mine each block

### DIFF
--- a/apps/miner/lib/miner.ex
+++ b/apps/miner/lib/miner.ex
@@ -20,6 +20,8 @@ defmodule Miner do
       List.first(chain)
       |> Block.initialize
 
+	IO.write "mining block #{block.index}...\r"
+	
 	before = :os.system_time
 	
     block =

--- a/apps/miner/lib/miner.ex
+++ b/apps/miner/lib/miner.ex
@@ -20,6 +20,8 @@ defmodule Miner do
       List.first(chain)
       |> Block.initialize
 
+	before = :os.system_time
+	
     block =
       block
       |> calculate_coinbase_amount
@@ -27,7 +29,11 @@ defmodule Miner do
       |> merge_block(block)
       |> Block.mine
 
-    IO.puts "\e[34mBlock hash at index #{block.index} calculated:\e[0m #{block.hash}, using nonce: #{block.nonce}"
+	blue = "\e[34m"
+	clear = "\e[0m"
+	elapsed = (:os.system_time - before) / 1000000000
+
+    IO.puts "#{blue}index:#{clear} #{block.index} #{blue}hash:#{clear} #{block.hash} #{blue}nonce:#{clear} #{block.nonce} #{blue}elapsed:#{clear} #{elapsed}s"
 
     case Validator.is_block_valid?(block, chain) do
       :ok -> main(Blockchain.add_block(chain, block), address)

--- a/core/block.ex
+++ b/core/block.ex
@@ -56,11 +56,7 @@ defmodule UltraDark.Blockchain.Block do
   """
   @spec mine(Block) :: Block
   def mine(block) do
-    %{index: index, hash: hash, previous_hash: previous_hash, timestamp: timestamp, nonce: nonce, merkle_root: merkle_root} = block
-
-    # I would love to show some sort of hashrate here, but it looks like getting the time with Elixir is incredibly computationally expensive,
-    # to the point where mining performance gets HALVED
-    IO.write "Block Index: #{index} -- Hash: #{hash} -- Nonce: #{nonce}\r"
+    %{index: index, previous_hash: previous_hash, timestamp: timestamp, nonce: nonce, merkle_root: merkle_root} = block
 
     block = %{ block | hash: Utilities.sha_base16([Integer.to_string(index), previous_hash, timestamp, Integer.to_string(nonce), merkle_root]) }
 


### PR DESCRIPTION
In the _miner_ app, it now prints the time it took to mine the block along with the index, hash, and nonce. I've also sped up the hash rate by not printing every hash.